### PR TITLE
Add Claude Code plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "overloop",
+  "description": "Sales automation CLI — manage prospects, campaigns, enrollments, and sourcings via the Overloop API. Build and run outbound sequences from Claude Code.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Nicolas Finet",
+    "email": "nicolas@overloop.com"
+  },
+  "homepage": "https://overloop.com",
+  "repository": "https://github.com/sortlist/overloop-cli",
+  "license": "MIT",
+  "keywords": ["sales", "outbound", "crm", "email", "campaigns", "prospecting", "automation"]
+}

--- a/agents/outbound-manager.md
+++ b/agents/outbound-manager.md
@@ -1,0 +1,37 @@
+---
+name: outbound-manager
+description: Specialized agent for building and managing Overloop outbound campaigns. Invoke when the user wants to set up a complete outbound sequence, source prospects, create multi-step campaigns, and manage enrollments. Knows the full Overloop CLI command set.
+model: sonnet
+maxTurns: 30
+---
+
+You are an outbound sales automation expert. You help users build and run outbound campaigns using the `overloop` CLI.
+
+You have deep knowledge of:
+- Prospect management (CRUD, search, filtering)
+- Campaign creation with multi-step sequences (email, delay, condition steps)
+- Prospect sourcing with search criteria (locations, industries, company sizes, job titles)
+- Enrollment management (single, bulk, scheduled)
+- Organization and list management
+- Exclusion list management
+- Conversation tracking
+
+## Your workflow
+
+When a user asks you to set up outbound:
+
+1. **Understand the target**: Ask about ICP (industry, location, company size, job titles) if not provided
+2. **Check account state**: Run `overloop me` and `overloop sending-addresses:list` to verify setup
+3. **Source or find prospects**: Either create a sourcing or search existing prospects
+4. **Build the campaign**: Create campaign, add steps in logical order (delay -> email -> delay -> email)
+5. **Set up exclusions**: Add competitor domains or specific emails to exclusion list
+6. **Enroll and activate**: Bulk enroll prospects and activate the campaign
+
+## Key rules
+
+- Always check if a campaign/prospect already exists before creating
+- Always add delay steps between emails (minimum 1 day)
+- Never activate a campaign without confirming with the user first
+- Use `jq` to parse JSON output from all CLI commands
+- Keep email copy concise and personalized using template variables like `{{first_name}}`, `{{company}}`
+- Rate limit is 600 req/min — batch operations when possible

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v overloop >/dev/null 2>&1 || (echo 'Overloop CLI not found. Install with: npm install -g overloop-cli' >&2 && exit 0)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/campaigns/SKILL.md
+++ b/skills/campaigns/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: campaigns
+description: Build and manage Overloop outbound campaigns — create campaigns, add email/delay/condition steps, enroll prospects, and monitor performance. Use when the user wants to set up outbound sequences or manage campaign workflows.
+---
+
+# Overloop Campaigns
+
+You have access to the `overloop` CLI to build and manage outbound email campaigns.
+
+## Prerequisites
+
+The CLI must be installed (`npm install -g overloop-cli`) and authenticated (`overloop login` or `OVERLOOP_API_KEY` env var).
+
+## Campaign Commands
+
+### List Campaigns
+```bash
+overloop campaigns:list [--page N] [--per-page N] [--sort field] [--filter JSON] [--expand steps,sourcing]
+```
+Filter by status: `--filter '{"status":"on"}'` (on, off, draft, archived)
+
+### Get Campaign Details
+```bash
+overloop campaigns:get <id> [--expand steps,sourcing]
+```
+
+### Create Campaign
+```bash
+overloop campaigns:create --name "Q1 Outreach" [--timezone "Europe/Brussels"] [--sender-id user_id] [--data JSON]
+```
+
+### Update Campaign (e.g. activate)
+```bash
+overloop campaigns:update <id> --status on
+```
+
+### Delete Campaign
+```bash
+overloop campaigns:delete <id>
+```
+
+## Step Commands
+
+Steps define the campaign sequence (emails, delays, conditions).
+
+### List Steps
+```bash
+overloop steps:list --campaign <campaign_id>
+```
+
+### Create Step
+```bash
+overloop steps:create --campaign <id> --type <type> --config '<JSON>'
+```
+
+Step types and configs:
+- **email**: `{"subject":"Hello {{first_name}}","content":"<p>Hi {{first_name}},</p>"}`
+- **delay**: `{"days_delay":3}`
+- **condition**: `{"field":"industry","operator":"equals","value":"Technology"}`
+
+Use `overloop step-types:list` to see all available types.
+
+### Update / Delete Step
+```bash
+overloop steps:update <step_id> --campaign <id> --config '<JSON>'
+overloop steps:delete <step_id> --campaign <id>
+```
+
+## Enrollment Commands
+
+### Enroll a Prospect
+```bash
+overloop enrollments:create --campaign <id> --prospect <prospect_id> [--step-id id] [--reenroll] [--start-at ISO_8601]
+```
+
+### Bulk Enroll (up to 100)
+```bash
+overloop enrollments:bulk --campaign <id> --prospect-ids "[id1,id2,id3]"
+```
+
+### List / Get / Remove Enrollments
+```bash
+overloop enrollments:list --campaign <id> [--page N] [--per-page N]
+overloop enrollments:get <enrollment_id> --campaign <id>
+overloop enrollments:delete <enrollment_id> --campaign <id>
+```
+
+## Typical Workflow
+
+1. Create campaign: `overloop campaigns:create --name "Cold Outreach"`
+2. Add delay step: `overloop steps:create --campaign $ID --type delay --config '{"days_delay":1}'`
+3. Add email step: `overloop steps:create --campaign $ID --type email --config '{"subject":"Quick question","content":"..."}'`
+4. Enroll prospects: `overloop enrollments:bulk --campaign $ID --prospect-ids "[...]"`
+5. Activate: `overloop campaigns:update $ID --status on`
+
+## Guidelines
+
+- Always create steps before enrolling prospects.
+- Use delay steps between emails (1-5 days is standard).
+- Campaigns must be activated (`--status on`) to start sending.
+- Use `--expand steps` when getting campaigns to see the full sequence.
+- Rate limit: 600 requests/minute.

--- a/skills/outbound/SKILL.md
+++ b/skills/outbound/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: outbound
+description: End-to-end outbound workflow — source prospects, create campaigns with steps, enroll, and activate. Also manage organizations, lists, sourcings, conversations, exclusion lists, and sending addresses. Use for full outbound sequence setup or account management.
+---
+
+# Overloop Outbound & Account Management
+
+You have access to the `overloop` CLI for end-to-end outbound sales automation.
+
+## Prerequisites
+
+The CLI must be installed (`npm install -g overloop-cli`) and authenticated (`overloop login` or `OVERLOOP_API_KEY` env var).
+
+## Sourcing Commands
+
+Find and import prospects matching criteria.
+
+```bash
+# Browse search options (locations, industries, company sizes)
+overloop sourcings:search-options --field locations -q "Belgium"
+overloop sourcings:search-options --field industries -q "tech"
+
+# Create a sourcing
+overloop sourcings:create --name "Belgian Sales Directors" \
+  --search-criteria '{"keywords":"sales director","locations":["Belgium"],"company_size":["11-50","51-200"]}'
+
+# Start / pause / clone
+overloop sourcings:start <id>
+overloop sourcings:pause <id>
+overloop sourcings:clone <id>
+
+# List sourcings
+overloop sourcings:list [--page N] [--per-page N]
+```
+
+## Organization Commands
+
+```bash
+overloop organizations:list [--page N] [--per-page N] [--search text]
+overloop organizations:get <id>
+overloop organizations:create --name "Acme Corp" [--website https://acme.com]
+overloop organizations:update <id> [--name "New Name"]
+overloop organizations:delete <id>
+```
+
+## List Commands
+
+```bash
+overloop lists:list [--page N] [--search text]
+overloop lists:get <id>
+overloop lists:create --name "Hot Leads"
+overloop lists:update <id> --name "Warm Leads"
+overloop lists:delete <id>
+```
+
+## Conversation Commands
+
+```bash
+overloop conversations:list [--page N] [--search text] [--archived]
+overloop conversations:get <id>
+overloop conversations:archive <id>
+overloop conversations:unarchive <id>
+overloop conversations:assign <id> --owner <user_id>
+```
+
+## Exclusion List
+
+Block emails or domains from being contacted.
+
+```bash
+overloop exclusion-list:list [--search text]
+overloop exclusion-list:create --value competitor.com --item-type domain
+overloop exclusion-list:create --value ceo@partner.com --item-type email
+overloop exclusion-list:delete <id>
+```
+
+## Account & Users
+
+```bash
+overloop account:get           # Account info
+overloop me                    # Current user
+overloop users:list            # All team users
+overloop users:get <id>        # Specific user
+overloop sending-addresses:list  # Email addresses
+overloop custom-fields:list [--type prospects]  # Custom fields
+```
+
+## Full Outbound Workflow
+
+Here is the end-to-end sequence for launching an outbound campaign:
+
+1. **Define ICP**: Check search options to build criteria
+   ```bash
+   overloop sourcings:search-options --field locations -q "France"
+   overloop sourcings:search-options --field industries -q "SaaS"
+   ```
+
+2. **Source prospects**: Create and run sourcing
+   ```bash
+   overloop sourcings:create --name "French SaaS" --search-criteria '{"keywords":"marketing director","locations":["France"],"industries":["Software"]}'
+   overloop sourcings:start <sourcing_id>
+   ```
+
+3. **Exclude competitors**: Block domains/emails
+   ```bash
+   overloop exclusion-list:create --value competitor.com --item-type domain
+   ```
+
+4. **Build campaign**: Create with steps
+   ```bash
+   overloop campaigns:create --name "French SaaS Outreach" --timezone "Europe/Paris"
+   overloop steps:create --campaign <id> --type delay --config '{"days_delay":1}'
+   overloop steps:create --campaign <id> --type email --config '{"subject":"Quick question about {{company}}","content":"..."}'
+   overloop steps:create --campaign <id> --type delay --config '{"days_delay":3}'
+   overloop steps:create --campaign <id> --type email --config '{"subject":"Following up","content":"..."}'
+   ```
+
+5. **Enroll prospects**: Add sourced prospects to campaign
+   ```bash
+   overloop enrollments:bulk --campaign <id> --prospect-ids "[id1,id2,...]"
+   ```
+
+6. **Activate**: Turn on the campaign
+   ```bash
+   overloop campaigns:update <id> --status on
+   ```
+
+## Guidelines
+
+- Always set up exclusion list before enrolling to avoid contacting wrong people.
+- Use `--expand` liberally to reduce API calls.
+- Check `overloop sending-addresses:list` to verify sender is configured.
+- Rate limit: 600 requests/minute.
+- All output is JSON — pipe through `jq` for extraction.

--- a/skills/prospects/SKILL.md
+++ b/skills/prospects/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: prospects
+description: Manage Overloop prospects — search, create, update, delete, and bulk operations. Use when the user wants to find prospects, add contacts, or manage their prospect database.
+---
+
+# Overloop Prospects
+
+You have access to the `overloop` CLI to manage prospects in the Overloop sales platform.
+
+## Prerequisites
+
+The CLI must be installed (`npm install -g overloop-cli`) and authenticated (`overloop login` or `OVERLOOP_API_KEY` env var).
+
+## Available Commands
+
+### List & Search Prospects
+```bash
+overloop prospects:list [--page N] [--per-page N] [--sort field] [--search text] [--filter JSON] [--expand relations]
+```
+- `--search` free-text search across all fields
+- `--filter` JSON object for field-level filtering
+- `--sort` field name, prefix `-` for descending (e.g. `-created_at`)
+- `--expand` comma-separated relations to include
+- Max 1000 per page
+
+### Get a Single Prospect
+```bash
+overloop prospects:get <id_or_email>
+```
+Accepts a prospect ID or email address.
+
+### Create a Prospect
+```bash
+overloop prospects:create --email john@example.com [--first-name John] [--last-name Doe] [--organization-id org_id] [--data JSON]
+```
+- `--email` is required
+- Use `--data` for custom fields: `--data '{"custom_fields":{"source":"linkedin"}}'`
+
+### Update a Prospect
+```bash
+overloop prospects:update <id> [--first-name Jane] [--last-name Doe] [--email new@email.com] [--organization-id org_id]
+```
+
+### Delete a Prospect
+```bash
+overloop prospects:delete <id>
+```
+
+## Output
+
+All commands return JSON. Use `jq` to extract fields:
+```bash
+overloop prospects:list --search "acme" | jq '.data[] | {id, email, first_name}'
+```
+
+## Guidelines
+
+- Always check if a prospect exists before creating (search by email) to avoid duplicates.
+- When creating many prospects, batch operations are more efficient.
+- Use `--expand` to get related data (organizations, enrollments) in a single call.
+- Rate limit: 600 requests/minute.


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/plugin.json` manifest so the repo can be installed as a Claude Code plugin
- 3 skills: `prospects` (CRUD), `campaigns` (steps + enrollments), `outbound` (full workflow + sourcing)
- 1 agent: `outbound-manager` — builds complete outbound pipelines
- 1 hook: checks CLI is installed on session start

## Why
Claude Code has an official plugin marketplace. This lets any Claude Code user install Overloop directly and use it from their terminal with AI assistance.

After merge, we submit via https://claude.ai/settings/plugins/submit with the repo URL.

## Test plan
- [ ] `claude plugin validate .` passes
- [ ] `claude --plugin-dir .` loads skills and agent
- [ ] `/overloop:prospects`, `/overloop:campaigns`, `/overloop:outbound` available
- [ ] Agent appears in `/agents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)